### PR TITLE
fix: make use of config.toml, implement config_path as argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,7 @@ dependencies = [
  "config",
  "crypto-hash",
  "ctrlc",
+ "dirs",
  "dotenvy",
  "ed25519",
  "ed25519-dalek",
@@ -1972,6 +1973,27 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4135,6 +4157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,6 +4624,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
@@ -5372,6 +5410,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "toml 0.8.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ mockall = "0.12.1"
 keystore = { git = "https://github.com/deltadevsde/keystore", rev = "40f21a41afd0654091bb0881665288034ab8533f" }
 pyroscope = "0.5.7"
 pyroscope_pprofrs = "0.2.7"
+toml = "0.8.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ keystore = { git = "https://github.com/deltadevsde/keystore", rev = "40f21a41afd
 pyroscope = "0.5.7"
 pyroscope_pprofrs = "0.2.7"
 toml = "0.8.14"
+dirs = "5.0.1"

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -138,6 +138,7 @@ pub fn load_config(args: CommandLineArgs) -> Result<Config, config::ConfigError>
         .config_path
         .unwrap_or_else(|| ".deimos/config.toml".to_string());
 
+    // if the config file doesn't exist, create it with the default values
     if !Path::new(&config_path).exists() {
         if let Some(parent) = Path::new(&config_path).parent() {
             fs::create_dir_all(parent).unwrap();
@@ -154,7 +155,7 @@ pub fn load_config(args: CommandLineArgs) -> Result<Config, config::ConfigError>
 
     let default_config = Config::default();
     let file_config: Config = settings.try_deserialize().unwrap_or_else(|e| {
-        println!("Failed to deserialize config file: {}", e);
+        debug!("Failed to deserialize config file: {}", e);
         Config::default()
     });
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 use config::{builder::DefaultState, ConfigBuilder, File};
+use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path, sync::Arc};
 
@@ -134,9 +135,10 @@ impl Default for Config {
 }
 
 pub fn load_config(args: CommandLineArgs) -> Result<Config, config::ConfigError> {
-    let config_path = args
-        .config_path
-        .unwrap_or_else(|| ".deimos/config.toml".to_string());
+    let config_path = args.config_path.unwrap_or_else(|| {
+        let home_dir = home_dir().expect("Failed to get home directory");
+        format!("{}/.deimos/config.toml", home_dir.to_string_lossy())
+    });
 
     // if the config file doesn't exist, create it with the default values
     if !Path::new(&config_path).exists() {
@@ -155,7 +157,7 @@ pub fn load_config(args: CommandLineArgs) -> Result<Config, config::ConfigError>
 
     let default_config = Config::default();
     let file_config: Config = settings.try_deserialize().unwrap_or_else(|e| {
-        debug!("Failed to deserialize config file: {}", e);
+        error!("deserializing config file: {}", e);
         Config::default()
     });
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,12 +1,9 @@
 use clap::{Parser, Subcommand};
-use config::{builder::DefaultState, ConfigBuilder, File, FileFormat};
-use serde::Deserialize;
-use std::sync::Arc;
+use config::{builder::DefaultState, ConfigBuilder, ConfigError, File, FileFormat};
+use serde::{Deserialize, Serialize};
+use std::{env, fs, path::Path, sync::Arc};
 
-use crate::da::{
-    CelestiaConnection,
-    LocalDataAvailabilityLayer
-};
+use crate::da::{CelestiaConnection, LocalDataAvailabilityLayer};
 
 use crate::da::DataAvailabilityLayer;
 
@@ -39,7 +36,7 @@ pub struct CommandLineArgs {
     epoch_time: Option<u64>,
 
     /// IP address for the webserver to listen on
-    #[arg(short, long)]
+    #[arg(long)]
     host: Option<String>,
 
     /// Port number for the webserver to listen on
@@ -49,26 +46,28 @@ pub struct CommandLineArgs {
     #[arg(long)]
     public_key: Option<String>,
 
+    #[arg(long)]
+    config_path: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub webserver: Option<WebServerConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub celestia_config: Option<CelestiaConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
-
-    pub log_level: String,
+    pub log_level: Option<String>,
     pub da_layer: DALayerOption,
     pub redis_config: Option<RedisConfig>,
     pub epoch_time: u64,
     pub public_key: Option<String>,
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "serde", derive(SerializeDisplay, DeserializeFromStr))]
 pub enum DALayerOption {
     #[default]
@@ -77,7 +76,7 @@ pub enum DALayerOption {
     None,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WebServerConfig {
     pub host: String,
     pub port: u16,
@@ -92,20 +91,20 @@ impl Default for WebServerConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RedisConfig {
-    pub connection_string: String
+    pub connection_string: String,
 }
 
 impl Default for RedisConfig {
     fn default() -> Self {
-        RedisConfig{
-            connection_string: "redis://127.0.0.1/".to_string()
+        RedisConfig {
+            connection_string: "redis://127.0.0.1/".to_string(),
         }
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CelestiaConfig {
     pub connection_string: String,
     pub namespace_id: String,
@@ -124,7 +123,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             webserver: Some(WebServerConfig::default()),
-            log_level: "DEBUG".to_string(),
+            log_level: Some("DEBUG".to_string()),
             da_layer: DALayerOption::default(),
             celestia_config: Some(CelestiaConfig::default()),
             redis_config: Some(RedisConfig::default()),
@@ -135,56 +134,70 @@ impl Default for Config {
 }
 
 pub fn load_config(args: CommandLineArgs) -> Result<Config, config::ConfigError> {
+    let config_path = args
+        .config_path
+        .unwrap_or_else(|| ".deimos/config.toml".to_string());
+
+    if !Path::new(&config_path).exists() {
+        if let Some(parent) = Path::new(&config_path).parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+
+        let default_config = Config::default();
+        let config_toml = toml::to_string(&default_config).unwrap();
+        fs::write(&config_path, config_toml).unwrap();
+    }
+
     let settings = ConfigBuilder::<DefaultState>::default()
-        .add_source(File::from_str(
-            include_str!("config.toml"),
-            FileFormat::Toml,
-        ))
+        .add_source(File::with_name(&config_path))
         .build()?;
 
-    info!("{}", settings.get_string("log_level").unwrap_or_default());
-
     let default_config = Config::default();
+    let file_config: Config = settings
+        .try_deserialize()
+        .unwrap_or_else(|_| Config::default());
+
+    // TODO: doesnt work rn because if one of the config fields is not present in the file, then it will take the default values for everything, even if the other fields are present in the file
+    let merged_config = Config {
+        log_level: file_config.log_level,
+        webserver: file_config.webserver.or(default_config.webserver),
+        redis_config: file_config.redis_config.or(default_config.redis_config),
+        celestia_config: file_config
+            .celestia_config
+            .or(default_config.celestia_config),
+        da_layer: file_config.da_layer,
+        epoch_time: file_config.epoch_time,
+        public_key: file_config.public_key.or(default_config.public_key),
+    };
 
     Ok(Config {
-        log_level: args.log_level.unwrap_or(default_config.log_level),
+        log_level: Some(args.log_level.unwrap_or(merged_config.log_level.unwrap())),
         webserver: Some(WebServerConfig {
             host: args
                 .host
-                .unwrap_or(default_config.webserver.as_ref().unwrap().host.clone()),
-            port: args
-                .port
-                .unwrap_or(default_config.webserver.as_ref().unwrap().port),
+                .unwrap_or(merged_config.webserver.clone().unwrap().host),
+            port: args.port.unwrap_or(merged_config.webserver.unwrap().port),
         }),
-        da_layer: DALayerOption::default(),
         redis_config: Some(RedisConfig {
-            connection_string: args.redis_client.unwrap_or(
-                default_config.redis_config.as_ref().unwrap().connection_string.clone()
-            )
+            connection_string: args
+                .redis_client
+                .unwrap_or(merged_config.redis_config.unwrap().connection_string),
         }),
         celestia_config: Some(CelestiaConfig {
             connection_string: args.celestia_client.unwrap_or(
-                default_config
+                merged_config
                     .celestia_config
-                    .as_ref()
+                    .clone()
                     .unwrap()
-                    .connection_string
-                    .clone(),
+                    .connection_string,
             ),
-            namespace_id: args.celestia_namespace_id.unwrap_or(
-                default_config
-                    .celestia_config
-                    .as_ref()
-                    .unwrap()
-                    .namespace_id
-                    .clone(),
-            ),
+            namespace_id: args
+                .celestia_namespace_id
+                .unwrap_or(merged_config.celestia_config.unwrap().namespace_id),
         }),
-        epoch_time: args
-            .epoch_time
-            .map(|e| e as u64)
-            .unwrap_or(default_config.epoch_time),
-        public_key: args.public_key.or(default_config.public_key),
+        da_layer: merged_config.da_layer,
+        epoch_time: args.epoch_time.unwrap_or(merged_config.epoch_time),
+        public_key: args.public_key.or(merged_config.public_key),
     })
 }
 
@@ -205,7 +218,9 @@ pub async fn initialize_da_layer(config: &Config) -> Arc<dyn DataAvailabilityLay
                 }
             }
         }
-        DALayerOption::InMemory => Arc::new(LocalDataAvailabilityLayer::new()) as Arc<dyn DataAvailabilityLayer + 'static>,
+        DALayerOption::InMemory => {
+            Arc::new(LocalDataAvailabilityLayer::new()) as Arc<dyn DataAvailabilityLayer + 'static>
+        }
         DALayerOption::None => panic!("No DA Layer"),
     }
 }

--- a/src/config.toml
+++ b/src/config.toml
@@ -1,1 +1,0 @@
-log_level = "INFO"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,9 @@ async fn main() -> std::io::Result<()> {
     let args = CommandLineArgs::parse();
     let config = load_config(args.clone()).unwrap();
 
-    std::env::set_var("RUST_LOG", &config.log_level);
+    println!("---------- STARTING Deimos node with config: {:?}", config);
+
+    std::env::set_var("RUST_LOG", &config.clone().log_level.unwrap());
 
     pretty_env_logger::init();
     dotenv().ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,6 @@ async fn main() -> std::io::Result<()> {
     let args = CommandLineArgs::parse();
     let config = load_config(args.clone()).unwrap();
 
-    println!("---------- STARTING Deimos node with config: {:?}", config);
-
     std::env::set_var("RUST_LOG", &config.clone().log_level.unwrap());
 
     pretty_env_logger::init();

--- a/src/node_types.rs
+++ b/src/node_types.rs
@@ -123,7 +123,10 @@ impl NodeType for LightClient {
                                     {
                                         trace!("valid signature for height {}", i);
                                     } else {
-                                        panic!("invalid signature in retrieved epoch on height {}", i);
+                                        panic!(
+                                            "invalid signature in retrieved epoch on height {}",
+                                            i
+                                        );
                                     }
                                 } else {
                                     error!("epoch on height {} was not signed", i);
@@ -179,7 +182,7 @@ impl Sequencer {
         Sequencer {
             db,
             da,
-            epoch_duration: cfg.epoch_time,
+            epoch_duration: cfg.epoch_time.unwrap(),
             ws: WebServer::new(cfg.webserver.unwrap()),
             key,
             epoch_buffer_tx: Arc::new(tx),
@@ -416,15 +419,16 @@ impl Sequencer {
     /// * `false` if the operation was unsuccessful, e.g., due to an invalid signature or other errors.
     ///
     pub fn update_entry(&self, signature: &UpdateEntryJson) -> bool {
-        debug!("updating entry for uid {} with msg {}", signature.id, signature.signed_message);
+        debug!(
+            "updating entry for uid {} with msg {}",
+            signature.id, signature.signed_message
+        );
         let signed_content = match verify_signature(signature, Some(signature.public_key.clone())) {
             Ok(content) => content,
             Err(_) => {
                 error!(
                     "updating entry for uid {}: invalid signature with pubkey {} on msg {}",
-                    signature.id,
-                    signature.public_key,
-                    signature.signed_message
+                    signature.id, signature.public_key, signature.signed_message
                 );
                 return false;
             }


### PR DESCRIPTION
**Changes**
1. Configuration Prioritization (make _really_ use of it):
- Command-line arguments take the highest priority.
- If not provided, values are sourced from the config.toml file.
- Any missing values are filled with default values.


2. Custom Configuration Path:
- A custom path for the config.toml file can now be specified via a command-line argument.
- By default, the configuration file is expected at ./deimos/config.toml.

3. Automatic Configuration File Creation:
- If the config.toml file does not exist at the specified/default path, it will be automatically created with the current default values.

4. Partial Configuration:
- It is now possible to define only a subset of configuration parameters in the config.toml file.
- Any unspecified parameters will "fall back" to their default values.

@distractedm1nd TODO: Readme / example config.toml? Or not necessary because of the automatic creation of the default one