### PR TITLE
Fix snarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,7 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexed-merkle-tree"
 version = "0.2.0"
-source = "git+https://github.com/deltadevsde/indexed-merkle-tree?rev=a22fd39242df3b08716fac6881e2f8f8cfd8642f#a22fd39242df3b08716fac6881e2f8f8cfd8642f"
+source = "git+https://github.com/deltadevsde/indexed-merkle-tree?rev=5f1836a99789c707f4636fe379b60e6294753aaf#5f1836a99789c707f4636fe379b60e6294753aaf"
 dependencies = [
  "cargo-audit",
  "crypto-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,9 +3689,8 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexed-merkle-tree"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ef352cb2039248110fa18e3f9bbcf1fac94c4d062bca23e40a88b4147a3c0c"
+version = "0.2.0"
+source = "git+https://github.com/deltadevsde/indexed-merkle-tree?rev=a22fd39242df3b08716fac6881e2f8f8cfd8642f#a22fd39242df3b08716fac6881e2f8f8cfd8642f"
 dependencies = [
  "cargo-audit",
  "crypto-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ clap = { version = "4.3.2", features = ["derive"] }
 config = "0.14.0"
 fs2 = "0.4.3"
 thiserror = "1.0.50"
-indexed-merkle-tree = "0.3.1"
+indexed-merkle-tree = { git = "https://github.com/deltadevsde/indexed-merkle-tree", rev = "a22fd39242df3b08716fac6881e2f8f8cfd8642f" }
 dotenvy = "0.15.7"
 ahash = "0.8.7"
 celestia-rpc = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ clap = { version = "4.3.2", features = ["derive"] }
 config = "0.14.0"
 fs2 = "0.4.3"
 thiserror = "1.0.50"
-indexed-merkle-tree = { git = "https://github.com/deltadevsde/indexed-merkle-tree", rev = "a22fd39242df3b08716fac6881e2f8f8cfd8642f" }
+indexed-merkle-tree = { git = "https://github.com/deltadevsde/indexed-merkle-tree", rev = "5f1836a99789c707f4636fe379b60e6294753aaf" }
 dotenvy = "0.15.7"
 ahash = "0.8.7"
 celestia-rpc = "0.2.0"

--- a/src/da.rs
+++ b/src/da.rs
@@ -500,10 +500,10 @@ mod da_tests {
             let prev_commitment = tree.get_commitment().unwrap();
 
             // insert a first node
-            let node_1 = create_node("test1", "test2");
+            let mut node_1 = create_node("test1", "test2");
 
             // generate proof for the first insert
-            let first_insert_proof = tree.insert_node(&node_1).unwrap();
+            let first_insert_proof = tree.insert_node(&mut node_1).unwrap();
             let first_insert_zk_snark = Proof::Insert(first_insert_proof);
 
             // create bls12 proof for posting
@@ -530,12 +530,12 @@ mod da_tests {
             let prev_commitment = tree.get_commitment().unwrap();
 
             // insert a second and third node
-            let node_2 = create_node("test3", "test4");
-            let node_3 = create_node("test5", "test6");
+            let mut node_2 = create_node("test3", "test4");
+            let mut node_3 = create_node("test5", "test6");
 
             // generate proof for the second and third insert
-            let second_insert_proof = tree.insert_node(&node_2).unwrap();
-            let third_insert_proof = tree.insert_node(&node_3).unwrap();
+            let second_insert_proof = tree.insert_node(&mut node_2).unwrap();
+            let third_insert_proof = tree.insert_node(&mut node_3).unwrap();
             let second_insert_zk_snark = Proof::Insert(second_insert_proof);
             let third_insert_zk_snark = Proof::Insert(third_insert_proof);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -216,34 +216,37 @@ mod tests {
         let ryan = sha256(&"Ryan".to_string());
         let ford = sha256(&"Ford".to_string());
         let sebastian = sha256(&"Sebastian".to_string());
-        //let pusch = sha256(&"Pusch".to_string());
+        let pusch = sha256(&"Pusch".to_string());
         let ethan = sha256(&"Ethan".to_string());
-        let triple_zero = sha256(&"TEst".to_string());
+        let triple_zero = sha256(&"000".to_string());
 
-        println!("Ryan: {:?}", ryan);
-        println!("Sebastian: {:?}", sebastian);
-        println!("Ethan: {:?}", ethan);
+        let mut ethans_node =
+            Node::new_leaf(true, true, ethan, triple_zero, Node::TAIL.to_string());
+        let mut ryans_node = Node::new_leaf(true, true, ryan, ford, Node::TAIL.to_string());
+        let mut sebastians_node =
+            Node::new_leaf(true, true, sebastian.clone(), pusch, Node::TAIL.to_string());
 
-        let ethans_node = Node::new_leaf(true, true, ethan, triple_zero, Node::TAIL.to_string());
-        let ryans_node = Node::new_leaf(true, true, ryan, ford, Node::TAIL.to_string());
-        /* let sebastians_node = Node::new_leaf(true, true, sebastian, pusch, Node::TAIL.to_string()); */
-
-        let first_insert_proof = tree.insert_node(&ryans_node).unwrap();
-        /* let second_insert_proof = tree.insert_node(&sebastians_node).unwrap(); */
-        let third_insert_proof = tree.insert_node(&ethans_node).unwrap();
-
-        println!("First insert proof: {:?}", first_insert_proof);
-        /* println!("Second insert proof: {:?}", second_insert_proof); */
-        println!("Third insert proof: {:?}", third_insert_proof);
+        let first_insert_proof = tree.insert_node(&mut ryans_node).unwrap();
+        let third_insert_proof = tree.insert_node(&mut ethans_node).unwrap();
+        let second_insert_proof = tree.insert_node(&mut sebastians_node).unwrap();
 
         let first_insert_zk_snark = Proof::Insert(first_insert_proof);
-        /* let second_insert_zk_snark = Proof::Insert(second_insert_proof); */
-        let third_insert_zk_snark = Proof::Insert(third_insert_proof);
+        let second_insert_zk_snark = Proof::Insert(second_insert_proof);
+        let third_insert_zk_snark = Proof::Insert(third_insert_proof.clone());
+
+        let updated_seb = sha256(&"Sebastian".to_string());
+        sebastians_node =
+            Node::new_leaf(true, true, sebastian, updated_seb, Node::TAIL.to_string());
+        let index = tree.find_node_index(&sebastians_node).unwrap();
+        let update_proof = tree.update_node(index, sebastians_node).unwrap();
+
+        let update_zk_snark = Proof::Update(update_proof);
 
         let proofs = vec![
-            third_insert_zk_snark,
             first_insert_zk_snark,
-            /* second_insert_zk_snark, */
+            second_insert_zk_snark,
+            third_insert_zk_snark,
+            update_zk_snark,
         ];
         let current_commitment = tree.get_commitment().unwrap();
 

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -117,7 +117,7 @@ async fn update_entry(
         Ok(_) => {
             let new_tree = session.create_tree().unwrap();
             let hashed_id = sha256(&signature_with_key.id);
-            let node = new_tree.find_leaf_by_label(&hashed_id).unwrap();
+            let mut node = new_tree.find_leaf_by_label(&hashed_id).unwrap();
 
             let proofs = if update_proof {
                 let new_index = tree.clone().find_node_index(&node).unwrap();
@@ -126,7 +126,7 @@ async fn update_entry(
                 format!(r#"{{"Update":{}}}"#, pre_processed_string)
             } else {
                 let pre_processed_string =
-                    serde_json::to_string(&tree.clone().insert_node(&node).unwrap()).unwrap();
+                    serde_json::to_string(&tree.clone().insert_node(&mut node).unwrap()).unwrap();
                 format!(r#"{{"Insert":{}}}"#, pre_processed_string)
             };
 

--- a/src/zk_snark/mod.rs
+++ b/src/zk_snark/mod.rs
@@ -90,14 +90,14 @@ pub fn decode_and_convert_to_g2affine(encoded_data: &String) -> Result<G2Affine,
 }
 
 fn unpack_and_process(proof: &MerkleProof) -> Result<(Scalar, &Vec<Node>), DeimosError> {
-    if !proof.path.is_empty() {
-        let scalar_root = hex_to_scalar(proof.root_hash.as_str()).map_err(DeimosError::General)?;
-        Ok((scalar_root, &proof.path))
-    } else {
-        Err(DeimosError::Proof(ProofError::ProofUnpackError(format!(
-            "proof path is empty for root hash {}",
-            proof.root_hash
-        ))))
+    match (&proof.root_hash, &proof.path) {
+        (Some(hex_root), Some(path)) if !path.is_empty() => {
+            let scalar_root = hex_to_scalar(hex_root).map_err(DeimosError::General)?;
+            Ok((scalar_root, path))
+        }
+        _ => Err(DeimosError::Proof(ProofError::ProofUnpackError(format!(
+            "proof path is empty for root hash "
+        )))),
     }
 }
 
@@ -602,7 +602,7 @@ impl Circuit<Scalar> for HashChainEntryCircuit {
 impl InsertMerkleProofCircuit {
     pub fn new(proof: &InsertProof) -> Result<InsertMerkleProofCircuit, DeimosError> {
         let (non_membership_root, non_membership_path) =
-            unpack_and_process(&proof.non_membership_proof.merkle_proof)?;
+            unpack_and_process(&proof.non_membership_proof)?;
 
         let first_merkle_circuit = UpdateMerkleProofCircuit::new(&proof.first_proof)?;
         let second_merkle_circuit = UpdateMerkleProofCircuit::new(&proof.second_proof)?;

--- a/src/zk_snark/mod.rs
+++ b/src/zk_snark/mod.rs
@@ -218,12 +218,12 @@ mod tests {
         let ford = sha256(&"Ford".to_string());
         let sebastian = sha256(&"Sebastian".to_string());
         let pusch = sha256(&"Pusch".to_string());
-        let ryans_node = Node::new_leaf(true, true, ryan, ford, TAIL.to_string());
-        let sebastians_node = Node::new_leaf(true, true, sebastian, pusch, TAIL.to_string());
+        let mut ryans_node = Node::new_leaf(true, true, ryan, ford, TAIL.to_string());
+        let mut sebastians_node = Node::new_leaf(true, true, sebastian, pusch, TAIL.to_string());
 
         // generate proofs for the two nodes
-        let first_insert_proof = tree.insert_node(&ryans_node).unwrap();
-        let second_insert_proof = tree.insert_node(&sebastians_node).unwrap();
+        let first_insert_proof = tree.insert_node(&mut ryans_node).unwrap();
+        let second_insert_proof = tree.insert_node(&mut sebastians_node).unwrap();
 
         // create zkSNARKs for the two proofs
         let first_insert_zk_snark = Proof::Insert(first_insert_proof);


### PR DESCRIPTION
The insert_operation ensures that the node is correctly assigned as a left or right child. In addition, the case has occurred that if a "new lowest" index is inserted last, the next pointers are not updated correctly. Both fixed here.