### PR TITLE
refactor: removing endpoints more suited for RPC calls

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,78 +12,10 @@ curl -X POST http://localhost:8080/update-entry \
             "signed_message": "YOUR_SIGNED_MESSAGE"}'
 ```
 
-### Get all derived and normal dictionary
-
-```bash
-curl http://localhost:8080/get-dictionaries
-```
-
-Returns both the tranparency dictionary with all entries and the derived dictionary containing only the hashed ids together with the hash value of the last block of the corresponding hashchain in the following format:
-
-```javascript
-{
-  "dict":[
-    { "id": "FIRST_ID",
-      "value": [
-        {"hash":"FIRST_BLOCK_HASH","previous_hash":"000..","operation":"...","value":"FIRST_HASHED_VALUE"}
-        {"hash":"SECOND_BLOCK_HASH","previous_hash":"FIRST_BLOCK_HASH","operation":"...","value":"SECOND_HASHED_VALUE"}
-      ]
-    },
-    { "id": "SECOND_ID",
-      "value": [
-        {"hash":"FIRST_BLOCK_HASH","previous_hash":"000...","operation":"...","value":"FIRST_HASHED_VALUE"}
-        {"hash":"SECOND_BLOCK_HASH","previous_hash":"FIRST_BLOCK_HASH","operation":"...","value":"SECOND_HASHED_VALUE"}
-      ]
-    },
-  ],
-  "derived_dict": [
-    { "id": "HASHED_FIRST_ID", "value": "HASH_OF_LAST_BLOCK"},
-    { "id": "HASHED_SECOND_ID", "value": "HASH_OF_LAST_BLOCK"}
-  ]
-}
-```
-
-### Get derived and normal dictionary for given ID
-
-```bash
-curl http://localhost:8080/get-dictionary/{ID}
-```
-
-Returns the tranparency dictionary with all entries for the given ID in the following format:
-
-```javascript
-{
-  "id": "ID",
-  "dict": [
-    { "hash": "FIRST_BLOCK_HASH", "previous_hash": "000...", "operation": "...", "value": "FIRST_HASHED_VALUE" },
-    { "hash": "SECOND_BLOCK_HASH", "previous_hash": "000...", "operation": "...", "value": "SECOND_HASHED_VALUE" },
-  ]
-}
-```
-
-### Validate epoch for given epoch number
-
-```bash
-curl -X POST http://localhost:8080/validate-epoch -H "Content-Type: application/json" -d '"EPOCH_NUMBER"'
-```
-
-This API request validates a Groth16 zk-SNARK created with the Merkle proofs of the past epoch. The EPOCH_NUMBER in the request should be replaced with the actual value of the epoch. The API response contains points on the BLS12-381 elliptical curve, represented by the keys 'a', 'b' and 'c' in the following format:
-
-```javascript
-{
-  "epoch": EPOCH-NUMBER,
-  "proof": {
-      "a": "A_COORDINATE",
-      "b": "B_COORDINATE",
-      "c": "C_COORDINATE"
-  }
-}
-```
-
 ### Get the current Merkle root
 
 ```bash
-curl http://localhost:8080/get-commitment
+curl http://localhost:8080/get-current-commitment
 ```
 
 Returns the current Merkle root as a string
@@ -92,99 +24,25 @@ Returns the current Merkle root as a string
 "{CURRENT_MERKLE_ROOT}";
 ```
 
-### Get the current Merkle tree
+### Get valid keys for a user
+
+The /get-valid-keys endpoint calculates the non-revoked values associated with an ID.
 
 ```bash
-curl http://localhost:8080/get-tree
+curl -X POST http://localhost:8080/get-valid-keys \
+      -H "Content-Type: application/json" \
+      -d '{
+            "id": "YOUR_ID"
+          }'
 ```
 
-Returns the entire current Merkle tree, starting at the root in the following format:
+ The function retrieves the hashchain associated with the provided ID from the database. It then iterates through the hashchain to find all
+ the non-revoked keys. The resulting list of non-revoked keys is returned as a JSON object like the following:
 
-```javascript
+ ```javascript
 {
-  "Inner": {
-    "hash": "ROOT_HASH",
-    "is_left_sibling": false,
-    "left": {
-      "Inner": {
-        "hash": "LEFT_CHILD_HASH",
-        "is_left_sibling": true,
-          "left": {
-            ...
-          },
-          "right": {
-            ...
-          }
-      }
-    },
-    "right": {
-      "Inner": {
-        "hash": "RIGHT_CHILD_HASH",
-        "is_left_sibling": false,
-        "left": {
-          ...
-        },
-        "right": {
-          ...
-        }
-      }
-    }
-  }
+  "values": [public_key1, public_key2, ...]
 }
-```
+ ```
 
-### Get all operations and Merkle proofs from a finanalized epoch
-
-```bash
-curl -X POST http://localhost:8080/get-epoch-operations -H "Content-Type: application/json" -d '"EPOCH"'
-```
-
-This API endpoint /get-epoch-operations accepts an epoch number and returns the previous and current commitment and a list of proofs for the specified epoch in the following format:
-
-```javascript
-{
-  "epoch": "EPOCH_NUMBER",
-  "previous_commitment": "PREVIOUS_COMMITMENT",
-  "current_commitment": "CURRENT_COMMITMENT",
-  "proofs": [
-    // e.g.
-    {
-      "Update": [
-        [ "OLD_ROOT",
-          [
-            { NODE_TO_PROVE },
-            { FIRST_SIBLING },
-            { PARENT_SIBLING },
-            { ... }
-          ]
-        ], [
-        [ "ROOT_AFTER_UPDATE",
-          [
-            { UPDATED_NODE_TO_PROVE },
-            { FIRST_SIBLING },
-            { PARENT_SIBLING },
-            { ... }
-          ]
-        ]]
-      ]}
-    ]
-}
-```
-
-### Get all epochs
-
-```bash
-curl http://localhost:8080/get-epochs
-```
-
-This API endpoint /get-epochs returns a sorted list of all available epochs together with the respective commitments. For each epoch, the epoch ID and the associated commitment are returned in the following form:
-
-```javascript
-{
-  "epochs": [
-    { "id": 0, "commitment":"COMMITMENT_EPOCH_0" },
-    { "id": 1, "commitment":"COMMITMNET_EPOCH_1" },
-    { "id": 2, "commitment":"COMMITMNET_EPOCH_2" }
-  ]
-}
-```
+If the ID is not found in the database, the endpoint will return a BadRequest response with the message "Could not calculate values".

--- a/API.md
+++ b/API.md
@@ -7,8 +7,7 @@ The update operation causes either the hashchain for an existing entry to be upd
 ```bash
 curl -X POST http://localhost:8080/update-entry \
       -H "Content-Type: application/json" \
-      -d '{ "id": "YOUR_ID", \
-            "public_key": "YOUR_PUBLIC_KEY", \
+      -d '{ "public_key": "YOUR_PUBLIC_KEY", \
             "signed_message": "YOUR_SIGNED_MESSAGE"}'
 ```
 

--- a/src/node_types/mod.rs
+++ b/src/node_types/mod.rs
@@ -13,7 +13,7 @@ pub trait NodeType {
 
 #[cfg(test)]
 mod tests {
-    use crate::{storage::UpdateEntryJson, utils::verify_signature};
+    use crate::{utils::verify_signature, webserver::UpdateEntryJson};
     use base64::{engine::general_purpose, Engine as _};
 
     fn setup_signature(valid_signature: bool) -> UpdateEntryJson {
@@ -25,8 +25,7 @@ mod tests {
         let id_public_key = "CosRXOoSLG7a8sCGx78KhtfLEuiyNY7L4ksFt78mp2M=".to_string();
 
         UpdateEntryJson {
-            id: id_public_key.clone(),
-            signed_message,
+            signed_incoming_entry: signed_message,
             public_key: id_public_key,
         }
     }
@@ -61,7 +60,7 @@ mod tests {
         let short_message = general_purpose::STANDARD.encode("this is a short message");
 
         let signature_with_key = UpdateEntryJson {
-            signed_message: short_message,
+            signed_incoming_entry: short_message,
             ..signature_with_key
         };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,6 +115,26 @@ pub trait Signable {
     fn get_public_key(&self) -> DeimosResult<String>;
 }
 
+pub fn decode_signed_message(signed_message: &String) -> DeimosResult<Vec<u8>> {
+    let signed_message_bytes = engine.decode(signed_message).map_err(|e| {
+        DeimosError::General(GeneralError::DecodingError(format!(
+            "signed message: {}",
+            e
+        )))
+    })?;
+
+    // check if the signed message is (at least) 64 bytes long
+    if signed_message_bytes.len() < 64 {
+        Err(GeneralError::ParsingError(format!(
+            "signed message is too short: {} < 64",
+            signed_message_bytes.len(),
+        ))
+        .into())
+    } else {
+        Ok(signed_message_bytes)
+    }
+}
+
 // verifies the signature of a given signable item and returns the content of the item if the signature is valid
 pub fn verify_signature<T: Signable>(
     item: &T,


### PR DESCRIPTION
This is a step in the right direction for the API, but we still need to sit down and make a better model for information flow from the endpoints to the internal services, and where types should live.

Later, we can make a lot of the endpoints I removed in this PR as part of an internal RPC.

A big TODO that this opened up for me is returning the merkle_proof for update_entry, so I will open an issue